### PR TITLE
Load error UI

### DIFF
--- a/src/burner/shock/includes.h
+++ b/src/burner/shock/includes.h
@@ -79,6 +79,7 @@
 #include "shock/ui/imagebinaries.h"
 #include "shock/ui/states/uibasestate.h"
 #include "shock/ui/states/stateloading.h"
+#include "shock/ui/states/stateloaderror.h"
 #include "shock/ui/states/statecredits.h"
 #include "shock/ui/states/statemainmenu.h"
 #include "shock/ui/states/stategamesettings.h"

--- a/src/burner/shock/shockconfig.cpp
+++ b/src/burner/shock/shockconfig.cpp
@@ -101,9 +101,10 @@ void ShockConfig::RestoreDefaults( )
     // due to corruption
     memset( &mConfigSettings, 0, sizeof( mConfigSettings ) );
     
-    mConfigSettings.displayMode = ShockDisplayMode_FullScreen;
-    mConfigSettings.scanLines   = 0;
-    mConfigSettings.showFPS     = 0;
+    mConfigSettings.displayMode      = ShockDisplayMode_FullScreen;
+    mConfigSettings.scanLines        = 0;
+    mConfigSettings.showFPS          = 0;
+    mConfigSettings.showLoadWarnings = 0;
 }
 
 int ShockConfig::GetDisplayMode( )
@@ -134,6 +135,16 @@ int ShockConfig::GetShowFPS( )
 void ShockConfig::SetShowFPS( int enabled )
 {
     mConfigSettings.showFPS = enabled;
+}
+
+int ShockConfig::GetShowLoadWarnings( )
+{
+    return mConfigSettings.showLoadWarnings;
+}
+
+void ShockConfig::SetShowLoadWarnings( int enabled )
+{
+    mConfigSettings.showLoadWarnings = enabled;
 }
 
 SavedFireInput *ShockConfig::LoadFireInputs( const char *pRomsetName )

--- a/src/burner/shock/shockconfig.h
+++ b/src/burner/shock/shockconfig.h
@@ -20,7 +20,8 @@ struct ConfigSettings
     int displayMode;
     int scanLines;
     int showFPS;
-    int reserved[ 1024 ]; //for future use
+    int showLoadWarnings;
+    int reserved[ 1020 ]; //for future use
     
     SavedFireInput savedConfigInputs[ MAX_GAMES ];
 };
@@ -42,6 +43,9 @@ public:
     
     static int  GetShowFPS( );
     static void SetShowFPS( int enabled );
+    
+    static int  GetShowLoadWarnings( );
+    static void SetShowLoadWarnings( int enabled );
     
     static SavedFireInput *LoadFireInputs( const char *pRomsetName );
     static void            SaveFireInputs( const char *pRomsetName, SavedFireInput *pFireInputs );

--- a/src/burner/shock/shockgame.cpp
+++ b/src/burner/shock/shockgame.cpp
@@ -42,7 +42,7 @@ UINT32 __cdecl HighCol16(INT32 r, INT32 g, INT32 b, INT32 /* i */);
 extern UINT8 *pBurnDraw;
 //***End Burn required implementations
 
-int ShockGame::LoadGame( const char *pRomset )
+LoadGameResult ShockGame::LoadGame( const char *pRomset )
 {
     // Grab the config file (we need it early, it controls CRC enforcement)
     ShockConfig::Create( );
@@ -57,11 +57,11 @@ int ShockGame::LoadGame( const char *pRomset )
     BurnLibInit( );
     
     // load the romset
-    int result = ShockRomLoader::LoadRomset( pRomset, 1, 1 );
+    int result = ShockRomLoader::LoadRomset( pRomset );
     if ( result == -1 )
     {
         flushPrintf( "ShockGame::LoadGame() - Romset %s not valid. Cannot continue.\r\n", ShockRomLoader::GetRomsetName( ) );
-        return -1;
+        return LoadGameResult_Failed_Load;
     }
     
     // FBA needs  a few things set PRIOR to initializing the driver,
@@ -97,14 +97,14 @@ int ShockGame::LoadGame( const char *pRomset )
     if( result == -1 )
     {
         flushPrintf( "ShockGame::LoadGame() - Failed to prepare rendering!\r\n" );
-        return -1;
+        return LoadGameResult_Failed_Other;
     }
     
     result = PrepareAudio( );
     if( result == -1 )
     {
         flushPrintf( "ShockGame::LoadGame() - Failed to prepare audio!\r\n" );
-        return -1;
+        return LoadGameResult_Failed_Other;
     }
     
     // everything is now setup - perform wrap up tasks now that we know what game we're playing
@@ -124,7 +124,7 @@ int ShockGame::LoadGame( const char *pRomset )
     
     mGameLoaded = 1;
    
-    return 0;
+    return LoadGameResult_Success;
 }
 
 void ShockGame::UnloadGame( )

--- a/src/burner/shock/shockgame.h
+++ b/src/burner/shock/shockgame.h
@@ -19,11 +19,18 @@ enum GameInputSwitchState
     GameInputSwitchState_PendingOn  =  1
 };
 
+enum LoadGameResult
+{
+    LoadGameResult_Success,
+    LoadGameResult_Failed_Load,
+    LoadGameResult_Failed_Other
+};
+
 class ShockGame
 {
 public:
-    static int  LoadGame( const char *pRomset );
-    static void UnloadGame( );
+    static LoadGameResult LoadGame( const char *pRomset );
+    static void           UnloadGame( );
     
     static void ResetFBATimer( );
     static void Update( );

--- a/src/burner/shock/shockmain.cpp
+++ b/src/burner/shock/shockmain.cpp
@@ -173,7 +173,7 @@ int ShockMain::UpdateState_Loading( )
         case LoadResult_Success:
         {
             // everything loaded, but were there warnings in the rom loader?
-            if( ShockRomLoader::GetLoadResult() != LOAD_SUCCESS 
+            if( (ShockRomLoader::GetLoadResult() & LOAD_WARNING_MASK) != 0
                 && ShockConfig::GetShowLoadWarnings( ) == 1 )
             {
                 // goto the load error state, where they can continue on.

--- a/src/burner/shock/shockmain.cpp
+++ b/src/burner/shock/shockmain.cpp
@@ -174,9 +174,7 @@ int ShockMain::UpdateState_Loading( )
         {
             // everything loaded, but were there warnings in the rom loader?
             if( ShockRomLoader::GetLoadResult() != LOAD_SUCCESS 
-            // TODO: AND does the user care? (check CRC setting)
-            
-              )
+                && ShockConfig::GetShowLoadWarnings( ) == 1 )
             {
                 // goto the load error state, where they can continue on.
                 ShockUI::SetState_LoadError( );

--- a/src/burner/shock/shockmain.h
+++ b/src/burner/shock/shockmain.h
@@ -10,6 +10,7 @@ enum ShockState
 {
     ShockState_Idle,
     ShockState_Loading,
+    ShockState_LoadError,
     ShockState_FrontEnd,
     ShockState_Emulator,
     ShockState_Count
@@ -20,7 +21,8 @@ enum LoadResult
     LoadResult_None,
     LoadResult_Pending,
     LoadResult_Success,
-    LoadResult_Failed,
+    LoadResult_Failed_Load,
+    LoadResult_Failed_Other,
     LoadResult_Count
 };
 
@@ -36,6 +38,7 @@ private:
     static void *LoadThread( void *pArg );
     
     static int   UpdateState_Loading( );
+    static int   UpdateState_LoadError( );
     static int   UpdateState_FrontEnd( );
     static int   UpdateState_Emulator( );
 

--- a/src/burner/shock/shockromloader.cpp
+++ b/src/burner/shock/shockromloader.cpp
@@ -34,8 +34,7 @@ int ShockRomLoader::LoadRomset( const char *pFilepath )
     result = ShockRomLoader::BurnGetDriverIndexByRomsetName( ShockRomLoader::mLoadedRomset_Name );
     if( result == -1 )
     {
-        mRomsetLoadResult = LOAD_FATAL_UNSUPPORTED;
-        
+        mRomsetLoadResult = LOAD_FATAL_UNSUPPORTED;   
         flushPrintf( "ShockRomLoader::LoadRomset() - BurnGetDriverIndexByRomsetName reports romset not found." 
                      "Verify this is a supported romset. Romset: %s\r\n", 
                      ShockRomLoader::mLoadedRomset_Name );
@@ -46,7 +45,6 @@ int ShockRomLoader::LoadRomset( const char *pFilepath )
     if( result == -1 )
     {
         mRomsetLoadResult = LOAD_FATAL_GENERIC;
-        
         flushPrintf( "ShockRomLoader::LoadRomset() - LoadRomInfoForActiveDriver failed\r\n" );
         return -1;
     }
@@ -55,7 +53,6 @@ int ShockRomLoader::LoadRomset( const char *pFilepath )
     if( result == -1 )
     {
         mRomsetLoadResult = LOAD_FATAL_GENERIC;
-        
         flushPrintf( "ShockRomLoader::LoadRomset() - LoadZipNamesForActiveDriver failed\r\n" );
         return -1;
     }

--- a/src/burner/shock/shockromloader.h
+++ b/src/burner/shock/shockromloader.h
@@ -18,6 +18,7 @@
 #define LOAD_FATAL_MISSING_ROM (0x1 << 3) 
 #define LOAD_WARNING_CRC       (0x1 << 4) //if this is set, there were crc issues (but they can be ignored)
 #define LOAD_WARNING_LEN       (0x1 << 5) //if this is set, there were size issues (but they can be ignored)
+#define LOAD_WARNING_MASK      (LOAD_WARNING_CRC | LOAD_WARNING_LEN)
 
 // Represents an individual rom within a Romset.
 // Really worth reading this: https://docs.mamedev.org/usingmame/aboutromsets.html

--- a/src/burner/shock/ui/render/menuitem.cpp
+++ b/src/burner/shock/ui/render/menuitem.cpp
@@ -12,9 +12,24 @@ void MenuItem::Create( const char *pText, int xPos, int yPos, short textColor )
     strncpy( mText, pText, sizeof( mText ) - 1 );
 }
 
+void MenuItem::SetText( const char *pText )
+{
+    strncpy( mText, pText, sizeof( mText ) - 1 );
+}
+
+const char *MenuItem::GetText( )
+{
+    return mText;
+}
+
 void MenuItem::SetColor( short textColor )
 {
     mTextColor = textColor;
+}
+
+short MenuItem::GetColor( )
+{
+    return mTextColor;
 }
 
 void MenuItem::Draw( )

--- a/src/burner/shock/ui/render/menuitem.h
+++ b/src/burner/shock/ui/render/menuitem.h
@@ -9,12 +9,16 @@ class MenuItem
 public:
     void Create( const char *pText, int xPos, int yPos, short textColor );
     
-    void SetColor( short textColor );
+    void        SetText( const char *pText );
+    const char *GetText( );
+    
+    void  SetColor( short textColor );
+    short GetColor( );
     
     void Draw( );
     
-    int  GetXPos( ) { return mXPos; }
-    int  GetYPos( ) { return mYPos; }
+    int GetXPos( ) { return mXPos; }
+    int GetYPos( ) { return mYPos; }
     
 private:
     int   mXPos;

--- a/src/burner/shock/ui/shockui.cpp
+++ b/src/burner/shock/ui/shockui.cpp
@@ -177,16 +177,19 @@ int ShockUI::UpdateState( )
     if( mState_MainMenu.ShouldExitUI( )
      || mState_LoadError.ShouldExitUI( ) )
     {
+        // put the state back to main menu for when we return
+        ChangeState( UIState_MainMenu );
         return 0;
     }
     
     if( mState_MainMenu.ShouldExitEmulator( )
      || mState_LoadError.ShouldExitEmulator( ) )
     {
+        // put the state back to main menu for when we return 
+        // (tho it doesnt matter since we'll be exiting the app)
+        ChangeState( UIState_MainMenu );
         return -1;
     }
-    
-    // special quit checks for load error state
     
     return 1;
 }

--- a/src/burner/shock/ui/shockui.cpp
+++ b/src/burner/shock/ui/shockui.cpp
@@ -11,6 +11,7 @@ StateDisplaySettings  ShockUI::mState_DisplaySettings;
 StateEmulatorSettings ShockUI::mState_EmulatorSettings;
 StateCredits          ShockUI::mState_Credits;
 StateLoading          ShockUI::mState_Loading;
+StateLoadError        ShockUI::mState_LoadError;
 UIBaseState          *ShockUI::mpStateList[ UIState_Count ];
 UINT16                ShockUI::mBackgroundImage[ PLATFORM_LCD_WIDTH * PLATFORM_LCD_HEIGHT ];
 long                  ShockUI::mFrameTimeMS;
@@ -60,6 +61,7 @@ void ShockUI::Create( )
     mpStateList[ UIState_GameSettings ]     = &mState_GameSettings;
     mpStateList[ UIState_Credits ]          = &mState_Credits;
     mpStateList[ UIState_Loading ]          = &mState_Loading;
+    mpStateList[ UIState_LoadError ]        = &mState_LoadError;
     
     // initialize our gamestates
     for( int i = 0; i < UIState_Count; i++ )
@@ -86,18 +88,22 @@ void ShockUI::Destroy( )
     UIRenderer::Destroy( );
 }
 
-void ShockUI::Activate( int enterLoadState )
+void ShockUI::SetState_Load( )
 {
-    mFrameTimeMS = gGlobalTimer.GetElapsedTimeMicroseconds();
-    
-    if ( enterLoadState == 1 )
-    {
-        ChangeState( UIState_Loading );
-    }
-    else
-    {
-        ChangeState( UIState_MainMenu );
-    }
+    mFrameTimeMS = gGlobalTimer.GetElapsedTimeMicroseconds( );
+    ChangeState( UIState_Loading );
+}
+
+void ShockUI::SetState_LoadError( )
+{
+    mFrameTimeMS = gGlobalTimer.GetElapsedTimeMicroseconds( );
+    ChangeState( UIState_LoadError );
+}
+
+void ShockUI::SetState_MainMenu( )
+{
+    mFrameTimeMS = gGlobalTimer.GetElapsedTimeMicroseconds( );
+    ChangeState( UIState_MainMenu );
 }
 
 int ShockUI::Update( )
@@ -166,16 +172,21 @@ int ShockUI::UpdateState( )
         }
     }    
     
-    // special quit checks
-    if( mState_MainMenu.ShouldExitUI( ) )
+    // special quit checks for the two states that can control
+    // full app state
+    if( mState_MainMenu.ShouldExitUI( )
+     || mState_LoadError.ShouldExitUI( ) )
     {
         return 0;
     }
     
-    if( mState_MainMenu.ShouldExitEmulator( ) )
+    if( mState_MainMenu.ShouldExitEmulator( )
+     || mState_LoadError.ShouldExitEmulator( ) )
     {
         return -1;
     }
+    
+    // special quit checks for load error state
     
     return 1;
 }

--- a/src/burner/shock/ui/shockui.h
+++ b/src/burner/shock/ui/shockui.h
@@ -13,7 +13,10 @@ public:
     static void Create( );
     static void Destroy( );
     
-    static void Activate( int enterLoadState );
+    static void SetState_Load( );
+    static void SetState_LoadError( );
+    static void SetState_MainMenu( );
+    
     static int  Update( );
     
 private:
@@ -29,6 +32,7 @@ private:
     static StateEmulatorSettings mState_EmulatorSettings;
     static StateCredits          mState_Credits;
     static StateLoading          mState_Loading;
+    static StateLoadError        mState_LoadError;
     static UIBaseState          *mpStateList[ UIState_Count ];
     static UINT16                mBackgroundImage[ PLATFORM_LCD_WIDTH * PLATFORM_LCD_HEIGHT ];
     static long                  mFrameTimeMS;

--- a/src/burner/shock/ui/states/statebuttonconfig.cpp
+++ b/src/burner/shock/ui/states/statebuttonconfig.cpp
@@ -56,7 +56,7 @@ void StateButtonConfig::EnterState( UIState oldState )
     memset( mButtonInputList    , 0, sizeof( mButtonInputList ) );
     
     int xPos = UI_X_POS_MENU;
-    int yPos = UI_Y_POS_MENU;
+    int yPos = UI_Y_POS_MENU + 20; // button graphics are too large to start at the normal offset
     
     int numPlayers = ShockBurnInput::GetNumPlayers();
     int i;
@@ -195,7 +195,7 @@ void StateButtonConfig::DrawMenu( )
                         mButtonInputList[ mPlayerSelection ][ mButtonSelection ].GetYPos( ),
                         UI_COLOR_ENABLED );
                         
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Return" );
 }
 
 int StateButtonConfig::GetPrevButtonInput( InputCodeToButtonMapping buttonIndex )

--- a/src/burner/shock/ui/states/statecredits.cpp
+++ b/src/burner/shock/ui/states/statecredits.cpp
@@ -85,7 +85,7 @@ void StateCredits::RenderCredits( )
         case 6: RenderPage6( ); break;
     }
     
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Return" );
     
     int prevTextColor = 0xFFFF;
     int nextTextColor = 0xFFFF;
@@ -115,7 +115,7 @@ void StateCredits::RenderPage0( )
     char text[ MAX_PATH ] = { 0 };
     
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     
     snprintf( text, sizeof( text ) - 1, "Version: %s", VERSION );
     UIRenderer::DrawText( text, xPos, yPos, 0xFFFF );
@@ -168,7 +168,7 @@ void StateCredits::RenderPage0( )
 void StateCredits::RenderPage1( )
 {
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     UIRenderer::DrawText( "(see below for a list of libraries with differing licenses,", xPos, yPos, 0xFFFF );
     yPos += UI_ROW_HEIGHT / 2;
     UIRenderer::DrawText( "please consult their respective documentation for more information):", xPos, yPos, 0xFFFF );
@@ -211,7 +211,7 @@ void StateCredits::RenderPage1( )
 void StateCredits::RenderPage2( )
 {
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     UIRenderer::DrawText( "FB Alpha would not exist without a lot of code from the MAME project.", xPos, yPos, 0xFFFF );
     
     yPos += UI_ROW_HEIGHT / 2;
@@ -276,7 +276,7 @@ void StateCredits::RenderPage2( )
 void StateCredits::RenderPage3( )
 {
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     UIRenderer::DrawText( "M6809 CPU core by John Bulter (http://www.mamedev.org).", xPos, yPos, 0xFFFF );
     
     yPos += UI_ROW_HEIGHT / 2;
@@ -354,7 +354,7 @@ void StateCredits::RenderPage3( )
 void StateCredits::RenderPage4()
 {
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     UIRenderer::DrawText( "UPD7759 sound core by Juergen Buchmueller, Mike Balfour,", xPos, yPos, 0xFFFF );
     yPos += UI_ROW_HEIGHT / 2;
     UIRenderer::DrawText( "Howie Cohen, Olivier Galibert, Aaron Giles (http://www.mamedev.org).", xPos, yPos, 0xFFFF );
@@ -407,7 +407,7 @@ void StateCredits::RenderPage4()
 void StateCredits::RenderPage5()
 {
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     UIRenderer::DrawText( "Some graphics effects provided by the Scale2x, 2xPM, Eagle Graphics,", xPos, yPos, 0xFFFF );
     yPos += UI_ROW_HEIGHT / 2;
     UIRenderer::DrawText( "2xSaI, hq2x/hq3x/hq4x, hq2xS/hq3xS/SuperEagle/2xSaI (VBA),", xPos, yPos, 0xFFFF );
@@ -457,7 +457,7 @@ void StateCredits::RenderPage5()
 void StateCredits::RenderPage6()
 {
     int xPos = UI_X_POS_MENU;
-    int yPos = 181;
+    int yPos = UI_Y_POS_MENU;
     UIRenderer::DrawText( "The following information and license conditions accompanied", xPos, yPos, 0xFFFF );
     
     yPos += UI_ROW_HEIGHT / 2;

--- a/src/burner/shock/ui/states/statedisplaysettings.cpp
+++ b/src/burner/shock/ui/states/statedisplaysettings.cpp
@@ -20,7 +20,7 @@ void StateDisplaySettings::Create( )
     mMenuItemList[ mNumMenuItems++ ].Create( "Full Screen", xPos, yPos, 0xFFFF );
     
     yPos += UI_ROW_HEIGHT * 3;
-    mMenuItemList[ mNumMenuItems++ ].Create( "Scanlines", xPos, yPos, 0xFFFF );
+    mMenuItemList[ mNumMenuItems++ ].Create( "Scanlines: ", xPos, yPos, 0xFFFF );
     
     memset( mResultStr, 0, sizeof( mResultStr ) );
     
@@ -122,14 +122,31 @@ void StateDisplaySettings::DrawMenu( )
                           305, // centers it on screen
                           mMenuItemList[ 3 ].GetYPos() - UI_ROW_HEIGHT, 
                           0xFFFF );
-    textColor = ShockConfig::GetScanLinesEnabled() == 1 ? textColor = UI_COLOR_ENABLED : 0xFFFF;
-    mMenuItemList[3].SetColor( textColor );
-    mMenuItemList[3].Draw( );
+                          
+    // Scanlines
+    char settingStr[ MAX_PATH ] = { 0 };
+    int menuItemLen = 0;
     
+    mMenuItemList[ 3 ].Draw( );
+    if ( ShockConfig::GetScanLinesEnabled( ) == 1 )
+    {
+        strncpy( settingStr, "On", sizeof( settingStr ) - 1 );
+        textColor = UI_COLOR_ENABLED;
+    }
+    else
+    {
+        strncpy( settingStr, "Off", sizeof( settingStr ) - 1 );
+        textColor = 0xFFFF;
+    }
+    
+    menuItemLen = Font::MeasureStringWidth( mMenuItemList[ 3 ].GetText( ) );
+    UIRenderer::DrawText( settingStr, mMenuItemList[ 3 ].GetXPos( ) + menuItemLen, mMenuItemList[ 3 ].GetYPos( ), textColor );
+    
+    // Cursor
     UIRenderer::DrawText( "X", 
                         mMenuItemList[ mMenuSelection ].GetXPos( ) - UI_CURSOR_X_OFFSET, 
                         mMenuItemList[ mMenuSelection ].GetYPos( ),
                         UI_COLOR_ENABLED );
     
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Return" );
 }

--- a/src/burner/shock/ui/states/stateemulatorsettings.cpp
+++ b/src/burner/shock/ui/states/stateemulatorsettings.cpp
@@ -11,10 +11,10 @@ void StateEmulatorSettings::Create( )
     
     int xPos = UI_X_POS_MENU;
     int yPos = UI_Y_POS_MENU;
-    mMenuItemList[ mNumMenuItems++ ].Create( "Display FPS Counter", xPos, yPos, 0xFFFF );
+    mMenuItemList[ mNumMenuItems++ ].Create( "Display FPS Counter: ", xPos, yPos, 0xFFFF );
     
     yPos += UI_ROW_HEIGHT;
-    mMenuItemList[ mNumMenuItems++ ].Create( "Display CRC Warning", xPos, yPos, 0xFFFF );
+    mMenuItemList[ mNumMenuItems++ ].Create( "Display Load Warnings: ", xPos, yPos, 0xFFFF );
     
     memset( mResultStr, 0, sizeof( mResultStr ) );
     
@@ -22,7 +22,10 @@ void StateEmulatorSettings::Create( )
     
     if ( mNumMenuItems > MAX_MENU_ITEMS )
     {
-        flushPrintf( "StateEmulatorSettings::Create() ERROR!!! mNumMenuItems too large at %d. MAX_MENU_ITEMS is only: %d\r\n", mNumMenuItems, MAX_MENU_ITEMS );
+        flushPrintf( "StateEmulatorSettings::Create() ERROR!!! mNumMenuItems too large at %d." 
+                     "MAX_MENU_ITEMS is only: %d\r\n", 
+                     mNumMenuItems, 
+                     MAX_MENU_ITEMS );
         exit( 0 );
     }
 }
@@ -74,6 +77,7 @@ UIState StateEmulatorSettings::Update( )
         }
         else if ( mMenuSelection == 1 )
         {
+            ShockConfig::SetShowLoadWarnings( !ShockConfig::GetShowLoadWarnings( ) );
         }
     }    
     
@@ -83,20 +87,46 @@ UIState StateEmulatorSettings::Update( )
 
 void StateEmulatorSettings::DrawMenu( )
 {
-    short textColor = ShockConfig::GetShowFPS( ) == 1 ? textColor = UI_COLOR_ENABLED : 0xFFFF;
-    mMenuItemList[0].SetColor( textColor );
-    mMenuItemList[0].Draw( );
+    char settingStr[ MAX_PATH ] = { 0 };
+    short textColor = 0;
+    int menuItemLen = 0;
     
+    // FPS
+    mMenuItemList[ 0 ].Draw( );
+    if ( ShockConfig::GetShowFPS( ) == 1 )
+    {
+        strncpy( settingStr, "On", sizeof( settingStr ) - 1 );
+        textColor = UI_COLOR_ENABLED;
+    }
+    else
+    {
+        strncpy( settingStr, "Off", sizeof( settingStr ) - 1 );
+        textColor = 0xFFFF;
+    }
     
-    textColor = 0xFFFF;//ShockConfig::GetDisplayMode() == 1 ? textColor = 0x87e0 : 0xFFFF;
-    mMenuItemList[1].SetColor( textColor );
-    mMenuItemList[1].Draw( );
+    menuItemLen = Font::MeasureStringWidth( mMenuItemList[ 0 ].GetText( ) );
+    UIRenderer::DrawText( settingStr, mMenuItemList[ 0 ].GetXPos( ) + menuItemLen, mMenuItemList[ 0 ].GetYPos( ), textColor );
     
+    // Load Warnings
+    mMenuItemList[ 1 ].Draw( );
+    if ( ShockConfig::GetShowLoadWarnings( ) == 1 )
+    {
+        strncpy( settingStr, "On", sizeof( settingStr ) - 1 );
+        textColor = UI_COLOR_ENABLED;
+    }
+    else
+    {
+        strncpy( settingStr, "Off", sizeof( settingStr ) - 1 );
+        textColor = 0xFFFF;
+    }
+    
+    menuItemLen = Font::MeasureStringWidth( mMenuItemList[ 1 ].GetText( ) );
+    UIRenderer::DrawText( settingStr, mMenuItemList[ 1 ].GetXPos( ) + menuItemLen, mMenuItemList[ 1 ].GetYPos( ), textColor );
     
     UIRenderer::DrawText( "X", 
                         mMenuItemList[ mMenuSelection ].GetXPos( ) - UI_CURSOR_X_OFFSET, 
                         mMenuItemList[ mMenuSelection ].GetYPos( ),
                         UI_COLOR_ENABLED );
     
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Return" );
 }

--- a/src/burner/shock/ui/states/stategamesettings.cpp
+++ b/src/burner/shock/ui/states/stategamesettings.cpp
@@ -21,7 +21,10 @@ void StateGameSettings::Create( )
     
     if ( mNumMenuItems > MAX_MENU_ITEMS )
     {
-        flushPrintf( "StateGameSettings::Create() ERROR!!! mNumMenuItems too large at %d. MAX_MENU_ITEMS is only: %d\r\n", mNumMenuItems, MAX_MENU_ITEMS );
+        flushPrintf( "StateGameSettings::Create() ERROR!!! mNumMenuItems too large at %d." 
+                     "MAX_MENU_ITEMS is only: %d\r\n", 
+                     mNumMenuItems, 
+                     MAX_MENU_ITEMS );
         exit( 0 );
     }
 }
@@ -144,5 +147,5 @@ void StateGameSettings::DrawMenu( )
                         mMenuItemList[ mMenuSelection ].GetYPos( ),
                         UI_COLOR_ENABLED );
                         
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Return" );
 }

--- a/src/burner/shock/ui/states/stategamesettings.h
+++ b/src/burner/shock/ui/states/stategamesettings.h
@@ -18,7 +18,8 @@ public:
     
 private:
     void      DrawMenu( );
-    
+
+private:
     MenuItem  mMenuItemList[ MAX_MENU_ITEMS ];
     int       mNumMenuItems;
     int       mMenuSelection;

--- a/src/burner/shock/ui/states/stateloaderror.cpp
+++ b/src/burner/shock/ui/states/stateloaderror.cpp
@@ -1,0 +1,162 @@
+
+// See License.md for license
+
+#include "../../includes.h"
+
+void StateLoadError::Create( )
+{
+    UIBaseState::Create( );
+    
+    mRomLoadResult     = 0;
+    mDisplayFatalError = 0;
+    mExitEmulator      = 0;
+    mExitUI            = 0;
+}
+
+void StateLoadError::Destroy( )
+{
+    UIBaseState::Destroy( );
+}
+
+void StateLoadError::EnterState( UIState oldState )
+{
+    UIBaseState::EnterState( oldState );
+    
+    // as we enter this state, lets figure out why we're being shown.
+    // it was either a warning due to CRC/Len, or a fatal error we can't continue from.
+    mRomLoadResult = ShockRomLoader::GetLoadResult();
+    
+    // if the success bit isn't set, this is a fatal error.
+    if( (mRomLoadResult & LOAD_SUCCESS) == 0 )
+    {
+        mDisplayFatalError = 1;
+    }
+    else
+    {
+        mDisplayFatalError = 0;
+    }
+}
+
+void StateLoadError::ExitState( UIState newState )
+{
+    UIBaseState::ExitState( newState );
+}
+
+UIState StateLoadError::Update( )
+{
+    UIBaseState::Update( );
+    
+    if( mDisplayFatalError == 1 )
+    {
+        RenderFatalError( );
+        
+        // check for player acknowledgement
+        if( ShockInput::GetInput( OptionsBack )->WasReleased( ) || 
+            ShockInput::GetInput( P1_Red )->WasReleased() )
+        {
+            mExitEmulator = 1;
+        }
+    }
+    else
+    {
+        RenderWarning( );
+        
+        // check for player acknowledgement
+        if( ShockInput::GetInput( OptionsBack )->WasReleased( ) || 
+            ShockInput::GetInput( P1_Red )->WasReleased() )
+        {
+            mExitUI = 1;
+        }
+    }
+    
+    // returning is different vs normal ui states, so don't use the base method
+    return UIState_Count;
+}
+
+int StateLoadError::ShouldExitUI( )
+{
+    return mExitUI;
+}
+
+int StateLoadError::ShouldExitEmulator( )
+{
+    return mExitEmulator;
+}
+
+void StateLoadError::RenderFatalError( )
+{
+    int xPos = 0;
+    int yPos = UI_Y_POS_MENU;
+    
+    char title[ MAX_PATH ] = { 0 };
+    strncpy( title, "Load Error", sizeof( title ) );
+    xPos = GetCenteredXPos( title );
+    UIRenderer::DrawText( title, xPos, yPos, 0xFFFF );
+        
+    if( mRomLoadResult & LOAD_FATAL_GENERIC )
+    {
+        char message[ MAX_PATH ] = { 0 };
+        snprintf( message, sizeof( message ), "%s could not be loaded", ShockRomLoader::GetRomsetName( ) );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    }
+    else if (mRomLoadResult & LOAD_FATAL_UNSUPPORTED )
+    {
+        char message[ MAX_PATH ] = { 0 };
+        snprintf( message, sizeof( message ), "%s is not a supported romset", ShockRomLoader::GetRomsetName( ) );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    }
+    else if ( mRomLoadResult & LOAD_FATAL_MISSING_ROM )
+    {
+        char message[ MAX_PATH ] = { 0 };
+        snprintf( message, sizeof( message ), "%s is missing roms:", ShockRomLoader::GetRomsetName( ) );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        // this is a tough one; we need to look up all missing roms
+        int numZipArchives = 0;
+        RomsetZipArchive *pZips = ShockRomLoader::ErrorHandling_GetLoadedRomset_ZipArchives( &numZipArchives );
+        
+        int numRoms = 0;
+        RomInfo *pRoms = ShockRomLoader::ErrorHandling_GetLoadedRoms( &numRoms );
+        
+        int i = 0;
+        for( i = 0; i < numRoms; i++ )
+        {
+            if( ShockRomLoader::ErrorHandling_RomRequired( &pRoms[ i ] ) )
+            {
+                if( pRoms[ i ].romFileFound == 0 )
+                {
+                    char message[ MAX_PATH ] = { 0 };
+                    snprintf( message, sizeof( message ), "%s", pRoms[ i ].burnRomInfo.szName );
+                    xPos = GetCenteredXPos( message );
+                    yPos += UI_ROW_HEIGHT / 2;
+                    UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+                }
+                
+                // stop if we run out of screen space
+                if ( yPos > PLATFORM_LCD_HEIGHT - (UI_ROW_HEIGHT * 2) )
+                {
+                    char message[ MAX_PATH ] = { 0 };
+                    snprintf( message, sizeof( message ), "More..." );
+                    xPos = GetCenteredXPos( message );
+                    yPos += UI_ROW_HEIGHT / 2;
+                    UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+                    break;
+                }
+            }
+        }
+    }
+    
+    UIBaseState::RenderBackOption( );
+}
+
+void StateLoadError::RenderWarning( )
+{
+    //TODO: Handle this. knightsu.zip is hacked so it'll work.
+    UIBaseState::RenderBackOption( );
+}

--- a/src/burner/shock/ui/states/stateloaderror.cpp
+++ b/src/burner/shock/ui/states/stateloaderror.cpp
@@ -7,10 +7,9 @@ void StateLoadError::Create( )
 {
     UIBaseState::Create( );
     
-    mRomLoadResult     = 0;
-    mDisplayFatalError = 0;
-    mExitEmulator      = 0;
-    mExitUI            = 0;
+    mRomLoadResult = 0;
+    mExitEmulator  = 0;
+    mExitUI        = 0;
 }
 
 void StateLoadError::Destroy( )
@@ -25,28 +24,22 @@ void StateLoadError::EnterState( UIState oldState )
     // as we enter this state, lets figure out why we're being shown.
     // it was either a warning due to CRC/Len, or a fatal error we can't continue from.
     mRomLoadResult = ShockRomLoader::GetLoadResult();
-    
-    // if the success bit isn't set, this is a fatal error.
-    if( (mRomLoadResult & LOAD_SUCCESS) == 0 )
-    {
-        mDisplayFatalError = 1;
-    }
-    else
-    {
-        mDisplayFatalError = 0;
-    }
 }
 
 void StateLoadError::ExitState( UIState newState )
 {
     UIBaseState::ExitState( newState );
+    
+    mExitEmulator = 0;
+    mExitUI       = 0;
 }
 
 UIState StateLoadError::Update( )
 {
     UIBaseState::Update( );
     
-    if( mDisplayFatalError == 1 )
+    // Fatal error?
+    if( (mRomLoadResult & LOAD_SUCCESS) == 0 )
     {
         RenderFatalError( );
         
@@ -88,31 +81,48 @@ void StateLoadError::RenderFatalError( )
     int xPos = 0;
     int yPos = UI_Y_POS_MENU;
     
-    char title[ MAX_PATH ] = { 0 };
-    strncpy( title, "Load Error", sizeof( title ) );
-    xPos = GetCenteredXPos( title );
-    UIRenderer::DrawText( title, xPos, yPos, 0xFFFF );
+    char message[ MAX_PATH ] = { 0 };
+    strncpy( message, "Load Error", sizeof( message ) );
+    xPos = GetCenteredXPos( message );
+    UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    
+    snprintf( message, sizeof( message ), "Romset: %s", ShockRomLoader::GetRomsetName( ) );
+    xPos = GetCenteredXPos( message );
+    yPos += UI_ROW_HEIGHT / 2;
+    UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
         
     if( mRomLoadResult & LOAD_FATAL_GENERIC )
     {
-        char message[ MAX_PATH ] = { 0 };
-        snprintf( message, sizeof( message ), "%s could not be loaded", ShockRomLoader::GetRomsetName( ) );
+        snprintf( message, sizeof( message ), "Could not be load romset" );
         xPos = GetCenteredXPos( message );
-        yPos += UI_ROW_HEIGHT;
+        yPos += UI_ROW_HEIGHT / 2;
         UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
     }
     else if (mRomLoadResult & LOAD_FATAL_UNSUPPORTED )
     {
-        char message[ MAX_PATH ] = { 0 };
-        snprintf( message, sizeof( message ), "%s is not a supported romset", ShockRomLoader::GetRomsetName( ) );
+        snprintf( message, sizeof( message ), "Romset not supported" );
         xPos = GetCenteredXPos( message );
-        yPos += UI_ROW_HEIGHT;
+        yPos += UI_ROW_HEIGHT / 2;
         UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
     }
     else if ( mRomLoadResult & LOAD_FATAL_MISSING_ROM )
     {
-        char message[ MAX_PATH ] = { 0 };
-        snprintf( message, sizeof( message ), "%s is missing roms:", ShockRomLoader::GetRomsetName( ) );
+        snprintf( message, sizeof( message ), "Roms Missing" );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "Make sure the romset is" );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "A parent, non-merged, or a clone with parent" );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "Missing roms are:" );
         xPos = GetCenteredXPos( message );
         yPos += UI_ROW_HEIGHT / 2;
         UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
@@ -131,7 +141,6 @@ void StateLoadError::RenderFatalError( )
             {
                 if( pRoms[ i ].romFileFound == 0 )
                 {
-                    char message[ MAX_PATH ] = { 0 };
                     snprintf( message, sizeof( message ), "%s", pRoms[ i ].burnRomInfo.szName );
                     xPos = GetCenteredXPos( message );
                     yPos += UI_ROW_HEIGHT / 2;
@@ -141,7 +150,6 @@ void StateLoadError::RenderFatalError( )
                 // stop if we run out of screen space
                 if ( yPos > PLATFORM_LCD_HEIGHT - (UI_ROW_HEIGHT * 2) )
                 {
-                    char message[ MAX_PATH ] = { 0 };
                     snprintf( message, sizeof( message ), "More..." );
                     xPos = GetCenteredXPos( message );
                     yPos += UI_ROW_HEIGHT / 2;
@@ -152,11 +160,59 @@ void StateLoadError::RenderFatalError( )
         }
     }
     
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Exit" );
 }
 
 void StateLoadError::RenderWarning( )
 {
-    //TODO: Handle this. knightsu.zip is hacked so it'll work.
-    UIBaseState::RenderBackOption( );
+    int xPos = 0;
+    int yPos = UI_Y_POS_MENU;
+    
+    char message[ MAX_PATH ] = { 0 };
+    strncpy( message, "Load Warning", sizeof( message ) );
+    xPos = GetCenteredXPos( message );
+    UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    
+    snprintf( message, sizeof( message ), "Romset: %s", ShockRomLoader::GetRomsetName( ) );
+    xPos = GetCenteredXPos( message );
+    yPos += UI_ROW_HEIGHT / 2;
+    UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    
+    if( mRomLoadResult & LOAD_WARNING_CRC )
+    {
+        snprintf( message, sizeof( message ), "CRC Validation" );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "ROM CRC values did not match what was expected." );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "This could simply mean this is a romhack." );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    }
+    
+    if( mRomLoadResult & LOAD_WARNING_LEN )
+    {
+        snprintf( message, sizeof( message ), "Size Validation" );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "Rom sizes did not match what was expected." );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+        
+        snprintf( message, sizeof( message ), "This may not impact the ability to play" );
+        xPos = GetCenteredXPos( message );
+        yPos += UI_ROW_HEIGHT / 2;
+        UIRenderer::DrawText( message, xPos, yPos, 0xFFFF );
+    }
+    
+    UIBaseState::RenderBackOption( "Continue" );
 }

--- a/src/burner/shock/ui/states/stateloaderror.h
+++ b/src/burner/shock/ui/states/stateloaderror.h
@@ -24,8 +24,6 @@ private:
     
 private:
     int mRomLoadResult;
-    int mDisplayFatalError;
-    
     int mExitEmulator;
     int mExitUI;
 };

--- a/src/burner/shock/ui/states/stateloaderror.h
+++ b/src/burner/shock/ui/states/stateloaderror.h
@@ -1,0 +1,33 @@
+
+// See License.md for license
+
+#ifndef STATELOADERROR_H_
+#define STATELOADERROR_H_
+
+class StateLoadError : public UIBaseState
+{
+public:
+    virtual void Create( );
+    virtual void Destroy( );
+    
+    virtual void EnterState( UIState oldState );
+    virtual void ExitState( UIState newState );
+    
+    virtual UIState Update( );    
+    
+            int     ShouldExitEmulator( );
+            int     ShouldExitUI( );
+    
+private:
+    void RenderFatalError( );
+    void RenderWarning( );
+    
+private:
+    int mRomLoadResult;
+    int mDisplayFatalError;
+    
+    int mExitEmulator;
+    int mExitUI;
+};
+
+#endif

--- a/src/burner/shock/ui/states/stateloading.cpp
+++ b/src/burner/shock/ui/states/stateloading.cpp
@@ -41,55 +41,31 @@ UIState StateLoading::Update( )
 
 void StateLoading::DrawMenu( )
 {
+    char loadStr[ MAX_PATH ] = { 0 };
+    snprintf( loadStr, sizeof( loadStr ), "LOADING GAME: %s", ShockRomLoader::GetRomsetName( ) );
+    int loadStrLen = strlen( loadStr );
+    
     if( mLoadingTimerMS < gGlobalTimer.GetElapsedTimeMicroseconds() )
     {
         mLoadingTimerMS = gGlobalTimer.GetElapsedTimeMicroseconds() + 100 * MILLI_TO_MICROSECONDS;
-        mLoadingColorLetterIndex = (mLoadingColorLetterIndex + 1) % 7;
+        mLoadingColorLetterIndex = (mLoadingColorLetterIndex + 1) % loadStrLen;
     }
         
     int whiteColor = 0xFFFF;
     int loadColor  = UI_COLOR_ENABLED;
     
-    int loadLength = Font::MeasureStringWidth( "LOADING" );
+    int loadLength = Font::MeasureStringWidth( loadStr );
     int xPos = (PLATFORM_LCD_WIDTH - loadLength) / 2;
-    UIRenderer::DrawText( "L", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 0 ? loadColor : whiteColor );
     
-    xPos += FONT_LETTER_FULL_WIDTH;
-    UIRenderer::DrawText( "O", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 1 ? loadColor : whiteColor );
-                        
-    xPos += FONT_LETTER_FULL_WIDTH;                    
-    UIRenderer::DrawText( "A", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 2 ? loadColor : whiteColor );
-                        
-    xPos += FONT_LETTER_FULL_WIDTH;
-    UIRenderer::DrawText( "D", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 3 ? loadColor : whiteColor );
-                        
-    xPos += FONT_LETTER_FULL_WIDTH;
-    UIRenderer::DrawText( "I", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 4 ? loadColor : whiteColor );
-                        
-    xPos += FONT_LETTER_FULL_WIDTH;
-    UIRenderer::DrawText( "N", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 5 ? loadColor : whiteColor );
-                        
-    xPos += FONT_LETTER_FULL_WIDTH;
-    UIRenderer::DrawText( "G", 
-                        xPos, 
-                        UI_Y_POS_MENU,
-                        mLoadingColorLetterIndex == 6 ? loadColor : whiteColor );
+    for( int i = 0; i < loadStrLen; i++ )
+    {
+        char letterStr[ MAX_PATH ] = { 0 };
+        letterStr[ 0 ] = loadStr[ i ];
+        UIRenderer::DrawText( letterStr, 
+                              xPos, 
+                              UI_Y_POS_MENU,
+                              mLoadingColorLetterIndex == i ? loadColor : whiteColor );
+                              
+        xPos += FONT_LETTER_FULL_WIDTH;
+    }
 }

--- a/src/burner/shock/ui/states/stateloading.h
+++ b/src/burner/shock/ui/states/stateloading.h
@@ -18,6 +18,7 @@ public:
 private:
     void      DrawMenu( );
     
+private:
     int       mLoadingColorLetterIndex;
     int       mLoadingTimerMS;
 };

--- a/src/burner/shock/ui/states/statemainmenu.cpp
+++ b/src/burner/shock/ui/states/statemainmenu.cpp
@@ -77,6 +77,9 @@ void StateMainMenu::EnterState( UIState oldState )
 void StateMainMenu::ExitState( UIState newState )
 {
     UIBaseState::ExitState( newState );
+    
+    mExitEmulator = 0;
+    mExitUI       = 0;
 }
     
 UIState StateMainMenu::Update( )
@@ -139,7 +142,7 @@ void StateMainMenu::DrawMenu( )
                         mMenuItemGameState[ mMenuSelection ].menuItem.GetYPos( ),
                         UI_COLOR_ENABLED );
                         
-    UIBaseState::RenderBackOption( );
+    UIBaseState::RenderBackOption( "Return" );
 }
 
 int StateMainMenu::ShouldExitUI( )

--- a/src/burner/shock/ui/states/statemainmenu.h
+++ b/src/burner/shock/ui/states/statemainmenu.h
@@ -27,6 +27,7 @@ public:
 private:
             void              DrawMenu( );
 
+private:
             int               mMenuSelection;
             int               mNumMenuItems;
             MenuItemUIState   mMenuItemGameState[ MAX_MENU_ITEMS ];

--- a/src/burner/shock/ui/states/uibasestate.cpp
+++ b/src/burner/shock/ui/states/uibasestate.cpp
@@ -38,5 +38,14 @@ UIState UIBaseState::HandleBackButton( )
 
 void UIBaseState::RenderBackOption( )
 {
-    UIRenderer::DrawText( "Press Options/Back to Return", UI_X_POS_MENU, PLATFORM_LCD_HEIGHT - 50, 0xFFFF );
+    char textStr[ MAX_PATH ] = { 0 };
+    snprintf( textStr, sizeof( textStr ), "Press Options/Back to Return" );
+    int xPos = GetCenteredXPos( textStr );
+    UIRenderer::DrawText( textStr, xPos, PLATFORM_LCD_HEIGHT - 50, 0xFFFF );
+}
+
+int UIBaseState::GetCenteredXPos( const char *pText )
+{
+    int width = Font::MeasureStringWidth( pText );
+    return (PLATFORM_LCD_WIDTH - width) / 2;
 }

--- a/src/burner/shock/ui/states/uibasestate.cpp
+++ b/src/burner/shock/ui/states/uibasestate.cpp
@@ -36,10 +36,10 @@ UIState UIBaseState::HandleBackButton( )
     }
 }
 
-void UIBaseState::RenderBackOption( )
+void UIBaseState::RenderBackOption( const char *pNavVerb)
 {
     char textStr[ MAX_PATH ] = { 0 };
-    snprintf( textStr, sizeof( textStr ), "Press Options/Back to Return" );
+    snprintf( textStr, sizeof( textStr ), "Press Options/Back to %s", pNavVerb );
     int xPos = GetCenteredXPos( textStr );
     UIRenderer::DrawText( textStr, xPos, PLATFORM_LCD_HEIGHT - 50, 0xFFFF );
 }

--- a/src/burner/shock/ui/states/uibasestate.h
+++ b/src/burner/shock/ui/states/uibasestate.h
@@ -15,6 +15,7 @@ enum UIState
     UIState_EmulatorSettings,
     UIState_Credits,
     UIState_Loading,
+    UIState_LoadError,
     UIState_Count
 };
 
@@ -40,10 +41,11 @@ public:
 protected:
     UIState HandleBackButton( );
     void    RenderBackOption( );
+    
+    int     GetCenteredXPos( const char *pText );
 
 protected:
-    UIState   mLastState;
-    int       mDrawBGImage;
+    UIState mLastState;
 };
 
 #endif

--- a/src/burner/shock/ui/states/uibasestate.h
+++ b/src/burner/shock/ui/states/uibasestate.h
@@ -19,7 +19,7 @@ enum UIState
     UIState_Count
 };
 
-#define UI_Y_POS_MENU      (200) //The start y position for menu items
+#define UI_Y_POS_MENU      (181) //The start y position for menu items
 #define UI_X_POS_MENU      (90)  //The start x position for menu items
 #define UI_ROW_HEIGHT      (56)  //The amount to increment Y by when rendering another line
 #define UI_CURSOR_X_OFFSET (52)  //The amount of pixels to decrement by when rendering the selection cursor
@@ -40,7 +40,7 @@ public:
     
 protected:
     UIState HandleBackButton( );
-    void    RenderBackOption( );
+    void    RenderBackOption( const char *pNavVerb);
     
     int     GetCenteredXPos( const char *pText );
 

--- a/src/fba.project
+++ b/src/fba.project
@@ -1339,6 +1339,8 @@
           <File Name="burner/shock/ui/states/stateemulatorsettings.h"/>
           <File Name="burner/shock/ui/states/stateloading.cpp"/>
           <File Name="burner/shock/ui/states/stateloading.h"/>
+          <File Name="burner/shock/ui/states/stateloaderror.cpp"/>
+          <File Name="burner/shock/ui/states/stateloaderror.h"/>
         </VirtualDirectory>
         <VirtualDirectory Name="render">
           <File Name="burner/shock/ui/render/drawlistobject.cpp"/>


### PR DESCRIPTION
Updates ShockRomLoader to store the issues found while attempting to load a romset.
Updates ShockMain and ShockGame to support a new Load Error state that will be entered if there are issues loading a romset.
Adds a new UI state, LoadError
Cleans up UI functions for switching to the frontend from the emulator
Replaced the "Display CRC Warnings" config option with "Display Load Warnings" and actually hooked it up
Cleaned up the layout of certain UI pages.