### PR TITLE
neogeo: overclock cpus: 68k (12->24Mhz) and z80 (4->8Mhz)

### DIFF
--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -132,7 +132,7 @@ struct NeoMediaInfo {
 #if defined Z80_SPEED_ADJUST
  static INT32 nZ80Clockspeed;
 #else
- static const INT32 nZ80Clockspeed = 4000000;
+ static const INT32 nZ80Clockspeed = 8000000;
 #endif
 
 #if defined RASTER_KLUDGE
@@ -3313,9 +3313,9 @@ void __fastcall neogeoWriteWordCDROM(UINT32 sekAddress, UINT16 wordValue)
 // LC8951RegistersR[1] |= 0x20;
 
 			if (nff0002 & 0x0500)
-				nNeoCDCyclesIRQPeriod = (INT32)(12000000.0 * nBurnCPUSpeedAdjust / (256.0 * 75.0));
+				nNeoCDCyclesIRQPeriod = (INT32)(24000000.0 * nBurnCPUSpeedAdjust / (256.0 * 75.0));
 			else
-				nNeoCDCyclesIRQPeriod = (INT32)(12000000.0 * nBurnCPUSpeedAdjust / (256.0 *  75.0));
+				nNeoCDCyclesIRQPeriod = (INT32)(24000000.0 * nBurnCPUSpeedAdjust / (256.0 *  75.0));
 
 			break;
 
@@ -3936,7 +3936,7 @@ static INT32 NeoInitCommon()
 	}
 
 #if defined Z80_SPEED_ADJUST
-	nZ80Clockspeed = 4000000;
+	nZ80Clockspeed = 8000000;
 #endif
 
 	if (nNeoSystemType & NEO_SYS_CART) {
@@ -4548,24 +4548,24 @@ INT32 NeoFrame()
 
 	if (nPrevBurnCPUSpeedAdjust != nBurnCPUSpeedAdjust) {
 		// 68K CPU clock is 12MHz, modified by nBurnCPUSpeedAdjust
-		nCyclesTotal[0] = (INT32)((INT64)12000000 * nBurnCPUSpeedAdjust / (256.0 * NEO_VREFRESH));
+		nCyclesTotal[0] = (INT32)((INT64)24000000 * nBurnCPUSpeedAdjust / (256.0 * NEO_VREFRESH));
 		
 #if defined Z80_SPEED_ADJUST
 		// Z80 CPU clock always 68K / 3
 		nCyclesTotal[1] = nCyclesTotal[0] / 3;
-		nZ80Clockspeed = (INT32)((INT64)4000000 * nBurnCPUSpeedAdjust / 256);
+		nZ80Clockspeed = (INT32)((INT64)8000000 * nBurnCPUSpeedAdjust / 256);
 		BurnTimerAttachZet(nZ80Clockspeed);
 #else
 		// Z80 CPU clock is always 4MHz
-		nCyclesTotal[1] = 4000000.0 / NEO_VREFRESH;
+		nCyclesTotal[1] = 8000000.0 / NEO_VREFRESH;
 #endif
 		// 68K cycles executed each scanline
 		SekOpen(0);
-		SekSetCyclesScanline((INT32)(12000000.0 * nBurnCPUSpeedAdjust / (256.0 * NEO_HREFRESH)));
+		SekSetCyclesScanline((INT32)(24000000.0 * nBurnCPUSpeedAdjust / (256.0 * NEO_HREFRESH)));
 		SekClose();
 
 		// uPD499A ticks per second (same as 68K clock)
-		uPD499ASetTicks((INT64)12000000 * nBurnCPUSpeedAdjust / 256);
+		uPD499ASetTicks((INT64)24000000 * nBurnCPUSpeedAdjust / 256);
 
 		nPrevBurnCPUSpeedAdjust = nBurnCPUSpeedAdjust;
 	}

--- a/src/burner/shock/input/shockplayerinput.cpp
+++ b/src/burner/shock/input/shockplayerinput.cpp
@@ -4,7 +4,7 @@
 #include "shock/input/shockinput.h"
 #include "shock/input/shockplayerinput.h"
 #include "shock/shockconfig.h"
-#include "shock/Shockfocus.h"
+#include "shock/shockfocus.h"
 #include "shock/shockprofiler.h"
 #include "shock/util/util.h"
 

--- a/src/burner/shock/shock.h
+++ b/src/burner/shock/shock.h
@@ -7,7 +7,7 @@
 #include "shock/systems.h"
 #include "burner.h"
 
-#define SHOCK_VERSION "1.0.3 (Build 0)"
+#define SHOCK_VERSION "1.0.3.neogeo.turbo"
 
 #ifdef _WIN64
     #define SHOCK_64BIT

--- a/src/burner/shock/ui/states/statecredits.cpp
+++ b/src/burner/shock/ui/states/statecredits.cpp
@@ -128,6 +128,8 @@ void StateCredits::RenderPage0( )
     UIRenderer::DrawText( "100 Mega Shock Edition Port Written by and # 2023 JHawkZZ", xPos, yPos, 0xFFFF );
     yPos += UI_ROW_HEIGHT / 2;
     UIRenderer::DrawText( "Quality Assurance by Usagi", xPos, yPos, 0xFFFF );
+	yPos += UI_ROW_HEIGHT / 2;
+    UIRenderer::DrawText( "Neogeo Turbo hack by BenDk97 (Mvsx France)", xPos, yPos, 0xFFFF );
                         
     yPos += UI_ROW_HEIGHT;
     UIRenderer::DrawText( "Some text uses the font Upheaval Pro by Brian Kent.", xPos, yPos, 0xFFFF );


### PR DESCRIPTION
Just to tell you something: I succeed to compile on arm the source code.

I just doubled frequency of neogeo cpus (68k and z80) and it works fine: original slowdowns almost disappear (try shock troopers 2, last resort, metal slug...etc)

It will be nice to add a setting in the emulator frontend (shock) to allow to set this variable: nBurnCPUSpeedAdjust

For example: cpu speed with default value to 100% and propose another values (120, .....200%)

My PR is just to show you that emulated overclocking is working well and has benefits. Some people will prefer original hardware with original slowdows, another will prefer to take advantage of emulation to make possible whit is impossible with real hardware